### PR TITLE
lib: fix link underline

### DIFF
--- a/lib/print.js
+++ b/lib/print.js
@@ -7,7 +7,7 @@ module.exports = function (list) {
     return `
 ${chalk.dim(`[${index}]`)} ${chalk.yellow(item.word)} ${chalk.red(figures.heart)} ${chalk.red(String(item.thumbs_up))}
 ${item.definition}
-${chalk.dim(`url: ${item.permalink.underline}`)}
+${chalk.underline.dim(`url: ${item.permalink}`)}
 ${chalk.dim(`example: ${item.example}`)}
 `.trim()
   }).join('\n\n'))


### PR DESCRIPTION
Before this commit the output was showing `undefined`:

	$ node cli.js car
	[0] car ♥ 83
	[LOOK AT THIS] DUDE WHY IS HE LOOKING UP [WHAT IS] A [CAR]
	url: undefined
	example: A [CAR] HAS [WHEELS]

	[1] Car ♥ 166
	[2-ton] steel carriages [powered] by [explosions], made out of dinosaurs which are used for transportation
	url: undefined
	example: I drove my car to the fuel station to fill [reservoir] with liquified [prehistoric] [reptiles].

	[2] car ♥ 1845
	[Men's] best [companion]. Often referred as "[My wife]".
	url: undefined
	example: "[Dude]! Where's my car?"

Now it properly shows the link:

	$ node cli.js car
	[0] car ♥ 83
	[LOOK AT THIS] DUDE WHY IS HE LOOKING UP [WHAT IS] A [CAR]
	url: http://car.urbanup.com/11163072
	example: A [CAR] HAS [WHEELS]

	[1] Car ♥ 166
	[2-ton] steel carriages [powered] by [explosions], made out of dinosaurs which are used for transportation
	url: http://car.urbanup.com/6477408
	example: I drove my car to the fuel station to fill [reservoir] with liquified [prehistoric] [reptiles].

	[2] car ♥ 1845
	[Men's] best [companion]. Often referred as "[My wife]".
	url: http://car.urbanup.com/118275
	example: "[Dude]! Where's my car?"